### PR TITLE
Fix transition bug and img loading bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "class-autobind": "^0.1.0",
     "classnames": "^2.0.0",
     "lodash.inrange": "^3.3.6",
-    "lodash.isequal": "^4.4.0",
     "lodash.merge": "^4.6.0",
     "lodash.nth": "^4.11.2",
     "ms": "^0.7.2"


### PR DESCRIPTION
This resolves 2 bugs:

1) When transitioning between slides, sometimes the carousel will jump to the next slide instead of smoothly animating. This was due to processing the onTransitionEnd event for one of the slide's opacity transitions instead of waiting for the transform event.

2) When rendering images that aren't cacheable locally, the slides will jump around as the images are loaded (even after being prefetched). The fix for this is to set an explicit width/height on the slide once the image dimensions are known so the UI doesn't jump.