### PR TITLE
bug fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -247,6 +247,9 @@ export default class Carousel extends Component {
   goToSlide (index, direction) {
     const { beforeChange, transitionDuration, transition } = this.props;
     const { currentSlide } = this.state;
+    if (currentSlide === index) {
+      return;
+    }
 
     if (this._animating) {
       return;
@@ -255,11 +258,9 @@ export default class Carousel extends Component {
     this._animating = true;
 
     beforeChange && beforeChange(index, currentSlide);
-
     this.setState({
       transitionDuration
     }, () => {
-
       this.setState({
         currentSlide: index,
         direction,
@@ -752,7 +753,7 @@ export default class Carousel extends Component {
    */
   onMouseLeave () {
     this.setHoverState(false);
-    this.stopDragging();
+    !this._animating && this.stopDragging();
   }
 
   /**

--- a/test/unit/carousel.tests.js
+++ b/test/unit/carousel.tests.js
@@ -148,6 +148,27 @@ describe('Carousel', () => {
     });
   });
 
+  it('should not freeze when a selected dot is clicked', done => {
+    renderToJsdom(
+      <Carousel slideWidth='300px' viewportWidth='300px' infinite={ false }>
+        <div id='slide1'/>
+        <div id='slide2'/>
+        <div id='slide3'/>
+      </Carousel>
+    );
+
+    setImmediate(() => {
+      const dots = document.querySelectorAll('.carousel-dot');
+      expect(dots.length).to.equal(3);
+      expect(dots[0].className).to.contain('selected');
+      Simulate.click(dots[0]);
+      Simulate.click(dots[2]);
+      expect(dots[0].className).to.not.contain('selected');
+      expect(dots[2].className).to.contain('selected');
+      done();
+    });
+  });
+
   it('should prefetch the specified number of images', done => {
     renderToJsdom(
       <Carousel slideWidth='300px' viewportWidth='300px' infinite={ false } imagesToPrefetch={ 3 }>


### PR DESCRIPTION
fix 2 bugs:
1. trigger selected control  again with goToSlide will cause the carousel go to a bad state and not responsive.
2. mouseLeave is called when there is other control over the carousel and when animating is in progress will cause the carousel go to a bad state.