### PR TITLE
adds z-index to selected slide

### DIFF
--- a/src/carousel.less
+++ b/src/carousel.less
@@ -88,6 +88,7 @@
       }
       &.carousel-slide-selected {
         opacity: 1;
+        z-index: 1;
       }
     }
   }


### PR DESCRIPTION
This is to ensure that the selected slide is always on top. In an app I am building the images in the slides have links. These links were not clickable because of this.