### PR TITLE
adds mouse inside slide feature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,8 +93,7 @@ export default class Carousel extends Component {
       dragOffset: 0,
       transitionDuration: 0,
       transitioningFrom: null,
-      leftOffset: 0,
-      paused: false
+      leftOffset: 0
     };
     autobind(this);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,8 @@ export default class Carousel extends Component {
       dragOffset: 0,
       transitionDuration: 0,
       transitioningFrom: null,
-      leftOffset: 0
+      leftOffset: 0,
+      paused: false
     };
     autobind(this);
   }
@@ -410,6 +411,7 @@ export default class Carousel extends Component {
               onTransitionEnd={ this.slideTransitionEnd }
               onMouseDown={ this.onMouseDown }
               onMouseLeave={ this.onMouseLeave }
+              onMouseOver={ this.onMouseOver }
               onMouseEnter={ this.onMouseEnter }
               onTouchStart={ this.onTouchStart }
             >
@@ -722,6 +724,20 @@ export default class Carousel extends Component {
    * Invoked when the mouse cursor enters over a slide.
    */
   onMouseEnter () {
+    document.addEventListener('mousemove', this.handleMovement, false);
+  }
+
+  /**
+   * Invoked when the mouse cursor moves around a slide.
+   */
+  handleMovement () {
+    this.setHoverState(true);
+  }
+
+  /**
+   * Invoked when the mouse cursor moves over a slide.
+   */
+  onMouseOver () {
     this.setHoverState(true);
   }
 
@@ -738,11 +754,13 @@ export default class Carousel extends Component {
 
       if (hovering) {
         clearTimeout(this._autoplayTimer);
+        this.setState({ paused: true });
         // If the mouse doesn't move for a few seconds, we want to restart the autoplay
         this._hoverTimer = setTimeout(() => {
           this.setHoverState(false);
         }, 2000);
       } else {
+        this.setState({ paused: false });
         this.startAutoplay();
       }
     }
@@ -752,6 +770,7 @@ export default class Carousel extends Component {
    * Invoked when the mouse cursor leaves a slide.
    */
   onMouseLeave () {
+    document.removeEventListener('mousemove', this.handleMovement, false);
     this.setHoverState(false);
     !this._animating && this.stopDragging();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -753,13 +753,11 @@ export default class Carousel extends Component {
 
       if (hovering) {
         clearTimeout(this._autoplayTimer);
-        this.setState({ paused: true });
         // If the mouse doesn't move for a few seconds, we want to restart the autoplay
         this._hoverTimer = setTimeout(() => {
           this.setHoverState(false);
         }, 2000);
       } else {
-        this.setState({ paused: false });
         this.startAutoplay();
       }
     }

--- a/test/unit/carousel.tests.js
+++ b/test/unit/carousel.tests.js
@@ -18,7 +18,6 @@ global.Image = class MyImage {
 };
 
 describe('Carousel', () => {
-
   beforeEach(() => {
     imagesFetched = [];
   });
@@ -211,6 +210,25 @@ describe('Carousel', () => {
         expect(dots[1].className).to.contain('selected');
         done();
       });
+    });
+  });
+
+  it('should pause when mouse is moving', done => {
+    const carousel = renderToJsdom(
+      <Carousel slideWidth='300px' viewportWidth='300px' infinite={ false } autoplay={ true } pauseOnHover={ true }>
+        <div id='slide1'/>
+        <div id='slide2'/>
+        <div id='slide3'/>
+      </Carousel>
+    );
+
+    setImmediate(() => {
+      const track = document.querySelector('.carousel-viewport');
+      carousel.handleMovement(track);
+      expect(carousel.state.paused).to.be.true;
+      carousel.onMouseLeave(track);
+      expect(carousel.state.paused).to.be.false;
+      done();
     });
   });
 

--- a/test/unit/carousel.tests.js
+++ b/test/unit/carousel.tests.js
@@ -216,19 +216,20 @@ describe('Carousel', () => {
   it('should pause when mouse is moving', done => {
     const carousel = renderToJsdom(
       <Carousel slideWidth='300px' viewportWidth='300px' infinite={ false } autoplay={ true } pauseOnHover={ true }>
-        <div id='slide1'/>
-        <div id='slide2'/>
-        <div id='slide3'/>
+        <div id='slide1' />
+        <div id='slide2' />
+        <div id='slide3' />
       </Carousel>
     );
 
     setImmediate(() => {
       const track = document.querySelector('.carousel-viewport');
+      const setHoverState = (bool) => {
+        expect(bool).to.be.true;
+        done();
+      };
+      carousel.setHoverState = setHoverState;
       carousel.handleMovement(track);
-      expect(carousel.state.paused).to.be.true;
-      carousel.onMouseLeave(track);
-      expect(carousel.state.paused).to.be.false;
-      done();
     });
   });
 


### PR DESCRIPTION
Increases the mouse over functionality. At the moment the slider only stops for 2 secs when entering or exiting the slide. This pull request changes that so that if moving the mouse inside the slide, the slider will pause.