### PR TITLE
Re-calculate left offset if slideWidth prop changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,13 +122,14 @@ export default class Carousel extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { children, autoplay } = this.props;
+    const { children, autoplay, slideWidth } = this.props;
     const { currentSlide, loadedImages, direction, loading } = this.state;
     const oldChildren = prevProps.children;
 
     if (direction !== prevState.direction ||
         currentSlide !== prevState.currentSlide ||
-        loadedImages !== prevState.loadedImages) {
+        loadedImages !== prevState.loadedImages ||
+        slideWidth !== prevProps.slideWidth) {
       // Whenever new images are loaded, the current slide index changes, or the transition direction changes, we need
       // to recalculate the left offset positioning of the slides.
       this.calcLeftOffset();

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ export default class Carousel extends Component {
         loadedImages !== prevState.loadedImages ||
         slideWidth !== prevProps.slideWidth) {
       // Whenever new images are loaded, the current slide index changes, the transition direction changes, or the
-      // slide with changes, we need to recalculate the left offset positioning of the slides.
+      // slide width changes, we need to recalculate the left offset positioning of the slides.
       this.calcLeftOffset();
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -130,8 +130,8 @@ export default class Carousel extends Component {
         currentSlide !== prevState.currentSlide ||
         loadedImages !== prevState.loadedImages ||
         slideWidth !== prevProps.slideWidth) {
-      // Whenever new images are loaded, the current slide index changes, or the transition direction changes, we need
-      // to recalculate the left offset positioning of the slides.
+      // Whenever new images are loaded, the current slide index changes, the transition direction changes, or the
+      // slide with changes, we need to recalculate the left offset positioning of the slides.
       this.calcLeftOffset();
     }
 


### PR DESCRIPTION
My use case requires sometimes changing `slideWidth`. Not sure if a test is needed/feasible.