### PR TITLE
Fix track style error and alter beforeChange signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ content.
 `PropTypes.func`
 
 Optional callback which will be invoked before a slide change occurs. Should have method signature
-`function(newIndex, prevIndex)`
+`function(newIndex, prevIndex, direction)`
 
 #### afterChange
 `PropTypes.func`

--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,7 @@ export default class Carousel extends Component {
 
     this._animating = true;
 
-    beforeChange && beforeChange(index, currentSlide);
+    beforeChange && beforeChange(index, currentSlide, direction);
     this.setState({
       transitionDuration
     }, () => {
@@ -386,7 +386,7 @@ export default class Carousel extends Component {
       width: viewportWidth,
       height: viewportHeight || slideHeight || 'auto'
     });
-    let trackStyle = style.track || {};
+    let trackStyle = merge({}, style.track || {});
     if (transition !== 'fade') {
       const leftPos = leftOffset + dragOffset;
       trackStyle = merge({}, trackStyle, {


### PR DESCRIPTION
- Fixes an issue where, if track inline styles were provided with `transition: 'fade'` and `draggable: false`, an attempt would be made to modify the track style object which was provided as a prop, throwing a read-only error.

- Changes the `beforeChange` callback to pass `direction` as a third parameter.