### PR TITLE
Fix timing issue with current image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.1 - Sept 2019
+
+***(Bug Fix)*** Fix issue that can cause the slideshow to never render
+
 # 1.5.0 - Sept 2019
 
 * ***(FEATURE)*** Add support for `maxRenderedSlides` prop


### PR DESCRIPTION
In order to determine when the currently selected image finished loading, we were cloning the `img` element and adding an `onLoad` handler. This handler was not getting invoked if the image prefetch code had managed to load the image before the actual DOM element was rendered, causing the carousel to never appear. A recent change seemed to widen this window and cause it to occur more frequently.

The fix is to immediately invoke the method when the prefetch logic finished loading the image rather than rendering another DOM element and using it to invoke the callback.