### PR TITLE
Fix issue where selected slide is not centered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.2 - Sept 2019
+
+***(Bug Fix)*** Fix issue that can cause the initial carousel positioning to be off
+
 # 1.5.1 - Sept 2019
 
 ***(Bug Fix)*** Fix issue that can cause the slideshow to never render

--- a/example.js
+++ b/example.js
@@ -38,14 +38,14 @@ class CustomDots extends React.Component {
 }
 
 const IMAGES = [
-  'http://lorempixel.com/400/300',
-  'http://lorempixel.com/275/300',
-  'http://lorempixel.com/400/300',
-  'http://lorempixel.com/350/300',
-  'http://lorempixel.com/250/300',
-  'http://lorempixel.com/375/300',
-  'http://lorempixel.com/425/300',
-  'http://lorempixel.com/325/300'
+  'http://picsum.photos/400/300',
+  'http://picsum.photos/275/300',
+  'http://picsum.photos/400/300',
+  'http://picsum.photos/350/300',
+  'http://picsum.photos/250/300',
+  'http://picsum.photos/375/300',
+  'http://picsum.photos/425/300',
+  'http://picsum.photos/325/300'
 ];
 let imgIndex = 1;
 
@@ -78,29 +78,29 @@ class TestPage extends Component {
         </Carousel>
         <h2 style={ { marginTop: 80 } }>Infinite with only 2 slides</h2>
         <Carousel width='450px' arrows={ false } slideHeight='300px'>
-          <img src='http://lorempixel.com/325/300'/>
-          <img src='http://lorempixel.com/350/300'/>
+          <img src='http://picsum.photos/325/300'/>
+          <img src='http://picsum.photos/350/300'/>
         </Carousel>
         <h2 style={ { marginTop: 80 } }>Infinite with only 1 slide</h2>
         <Carousel width='450px' infinite={ true } arrows={ false } dots={ false }>
-          <img src='http://lorempixel.com/325/300'/>
+          <img src='http://picsum.photos/325/300'/>
         </Carousel>
         <h2 style={ { marginTop: 80 } }>Autoplay with background images</h2>
         <Carousel width='100%' slideWidth='100%' slideHeight='70vh' arrows={ false } autoplay={ true }>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/600/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/650/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/675/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/700/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/600/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/650/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/675/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/700/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
         </Carousel>
         <h2 style={ { marginTop: 80 } }>Background images with fade</h2>
         <Carousel width='100%' slideWidth='100%' slideHeight='70vh' transition='fade' transitionDuration={ 1000 } autoplay={ true } arrows={ true }>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/600/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/650/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/675/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/700/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/750/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/725/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
-          <div style={ { backgroundImage: 'url(http://lorempixel.com/625/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/600/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/650/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/675/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/700/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/750/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/725/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
+          <div style={ { backgroundImage: 'url(http://picsum.photos/625/300)', backgroundSize: 'cover', height: '100%', width: '100%' } }/>
         </Carousel>
         <h2 style={ { marginTop: 80 } }>Custom dots component</h2>
         <Carousel


### PR DESCRIPTION
This PR fixes an issue where the carousel does not render with the correct initial positioning in some cases. If the selected slide's photo loads before the adjacent slides, the calculation of the positioning can be off, causing the initial view to show the wrong slide. This PR adds logic to detect this scenario (0-width slides with content to the left of the selected slide) and adds retry logic to recalculate the positioning once the slides are loaded. It also delays setting the `loaded` state until the correct positioning has been achieved, so that the carousel won't be initially rendered with the wrong positioning before snapping to the right place.

Before:

<img width="637" alt="Screen Shot 2019-09-24 at 9 38 47 AM" src="https://user-images.githubusercontent.com/7255994/65521635-2309d200-deaf-11e9-9f8d-64163091a405.png">


After:

<img width="696" alt="Screen Shot 2019-09-24 at 9 40 11 AM" src="https://user-images.githubusercontent.com/7255994/65521754-577d8e00-deaf-11e9-9b56-62cfd7dedcc7.png">
