### PR TITLE
Add preventDefaults prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ The easing function to use for the transition. Defaults to `ease-in-out`.
 Controls whether or not clicking slides other than the currently selected one should navigate to the clicked slide.
 Defaults to `true`.
 
+#### preventDefaults
+`PropTypes.bool`
+
+Controls whether or not clicking on slides will call `preventDefault` on the mousedown event.
+Defaults to `true`.
+
 #### autoplay
 `PropTypes.bool`
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ export default class Carousel extends Component {
       pauseOnHover: PropTypes.bool,
       clickToNavigate: PropTypes.bool,
       dragThreshold: PropTypes.number,
+      preventDefaults: PropTypes.bool,
       easing: PropTypes.oneOf([
         'ease',
         'linear',
@@ -89,6 +90,7 @@ export default class Carousel extends Component {
       controls: [],
       draggable: true,
       pauseOnHover: true,
+      preventDefaults: true,
       transition: 'slide',
       dragThreshold: 0.2,
       clickToNavigate: true,
@@ -727,9 +729,11 @@ export default class Carousel extends Component {
    * @param {Event} e DOM event object.
    */
   onMouseDown(e) {
-    const { draggable, transition } = this.props;
+    const { draggable, transition, preventDefaults } = this.props;
 
-    e.preventDefault();
+    if (preventDefaults) {
+      e.preventDefault();
+    }
 
     if (draggable && transition !== 'fade' && !this._animating) {
       if (this._autoplayTimer) {


### PR DESCRIPTION
The carousel currently calls preventDefault for the mousedown event on slides. This change introduces a prop, `preventDefaults`, which defaults to `true` but allows for this functionality to be disabled if desired.