### PR TITLE
Limit preventDefault calls in mousedown to only img elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -729,7 +729,11 @@ export default class Carousel extends Component {
   onMouseDown(e) {
     const { draggable, transition } = this.props;
 
-    e.preventDefault();
+    if (e.target.nodeName === 'IMG') {
+      // Disable native browser select/drag for img elements
+      e.preventDefault();
+    }
+
 
     if (draggable && transition !== 'fade' && !this._animating) {
       if (this._autoplayTimer) {


### PR DESCRIPTION
We only need to call `preventDefault` when the target of the mousedown event is an `img` element. This will allow for non-img slides to handle mouse events more effectively while still preserving the desired effect of blocking the native browser behavior of dragging the image out of the carousel.

Ideally, JS wouldn't be needed here and we would simply add `user-select: none` and `draggable="false"` to the `img` tags, but unfortunately a bug in FF prevents this from working (https://bugzilla.mozilla.org/show_bug.cgi?id=1376369)