### PR TITLE
Fix Safari style issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1 - May 2021
+
+***(Bug Fix)*** Fixes a bug in Safari 14.1 and Mobile Safari where carousel content is not visible in some scenarios
+
 # 2.0.0 - Dec 2020
 
 ***(Enhancement)*** Breaking change to optimize the bundle for modern browsers (may break legacy browser support)

--- a/src/carousel.less
+++ b/src/carousel.less
@@ -86,7 +86,7 @@
       display: inline-block;
       opacity: 0.7;
       transition: opacity 0.5s ease-in-out;
-      white-space: initial;
+      white-space: unset;
 
       & > * {
         display: block;


### PR DESCRIPTION
This fixes an issue where the carousel content is not visible in Safari 14.1 and mobile Safari. It appears that with the value `initial` the `li` elements are actually stacked vertically instead of horizontally (`inline-block` is not being honored).