### PR TITLE
Fix long slide content not wrapping by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.3 - May 2021
+
+***(Bug Fix)*** Fixes an issue introduced by 2.0.1 where long text content on slides is no longer wrapping
+
 # 2.0.2 - May 2021
 
 ***(Bug Fix)*** Fixes a bug when clicking to navigate to a particular slide and crossing the end or beginning of the list

--- a/src/carousel.less
+++ b/src/carousel.less
@@ -86,10 +86,10 @@
       display: inline-block;
       opacity: 0.7;
       transition: opacity 0.5s ease-in-out;
-      white-space: unset;
 
       & > * {
         display: block;
+        white-space: normal;
       }
       &.carousel-slide-loading {
         background: rgba(204, 204, 204, 0.7);


### PR DESCRIPTION
This fixes an issue introduced with the 2.0.1 release where long text content on slides is no longer wrapping as expected. Previously we were resetting the `white-space` style on the `li` element, which broke due to a recent change to webkit. This PR reintroduces the `white-space` reset but applies it to the slide content instead of the `li` itself.