### PR TITLE
Fix incorrect index index passed to beforeChange with infinite scrolling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,7 @@ export default class Carousel extends Component {
 
     this._animating = true;
 
-    beforeChange && beforeChange(index, currentSlide, direction);
+    beforeChange && beforeChange(newIndex, currentSlide, direction);
     this.setState({
       transitionDuration
     }, () => {

--- a/test/unit/carousel.tests.js
+++ b/test/unit/carousel.tests.js
@@ -109,13 +109,15 @@ describe('Carousel', () => {
 
   it('should wrap around from the last to first slide if infinite is true and next is clicked', done => {
     const onSlideTransitionedStub = sinon.stub();
+    const beforeChangeStub = sinon.stub();
 
     renderToJsdom(
       <Carousel initialSlide={ 2 }
         slideWidth='300px'
         viewportWidth='300px'
         infinite={ true }
-        onSlideTransitioned={ onSlideTransitionedStub }>
+        onSlideTransitioned={ onSlideTransitionedStub }
+        beforeChange={ beforeChangeStub }>
         <div id='slide1'/>
         <div id='slide2'/>
         <div id='slide3'/>
@@ -136,6 +138,7 @@ describe('Carousel', () => {
         index: 0,
         direction: 'right'
       });
+      expect(beforeChangeStub).to.have.been.calledWith(0, 2, 'right');
       done();
     });
   });

--- a/test/unit/carousel.tests.js
+++ b/test/unit/carousel.tests.js
@@ -141,8 +141,10 @@ describe('Carousel', () => {
   });
 
   it('should wrap around from the first to last slide if infinite is true and prev is clicked', done => {
+    const beforeChangeStub = sinon.stub();
+
     renderToJsdom(
-      <Carousel initialSlide={ 2 } slideWidth='300px' viewportWidth='300px' infinite={ true }>
+      <Carousel initialSlide={ 0 } slideWidth='300px' viewportWidth='300px' infinite={ true } beforeChange={ beforeChangeStub }>
         <div id='slide1'/>
         <div id='slide2'/>
         <div id='slide3'/>
@@ -152,12 +154,13 @@ describe('Carousel', () => {
     setImmediate(() => {
       let dots = tree.find('.carousel-dot');
       expect(dots.length).to.equal(3);
-      expect(dots.at(2).prop('className')).to.contain('selected');
-      const nextButton = tree.find('.carousel-right-arrow');
-      nextButton.simulate('click');
-      dots = tree.find('.carousel-dot');
-      expect(dots.at(2).prop('className')).to.not.contain('selected');
       expect(dots.at(0).prop('className')).to.contain('selected');
+      const prevButton = tree.find('.carousel-left-arrow');
+      prevButton.simulate('click');
+      dots = tree.find('.carousel-dot');
+      expect(dots.at(0).prop('className')).to.not.contain('selected');
+      expect(dots.at(2).prop('className')).to.contain('selected');
+      expect(beforeChangeStub).to.have.been.calledWith(2, 0, 'left');
       done();
     });
   });


### PR DESCRIPTION
## Issue
The `beforeChange` event is receiving the incorrect index when 'wrapping around' with infinite scrolling.

e.g. if current index is 0 and 'previous' button is hit, the index to `beforeChange` will come through as -1. Am expecting it to be the index of the **last** slide.

## Cause
An update in v2.0.2 moved the wrap around index calculation (variable `newIndex`) away from the individual methods calling `goToSlide` and placed it inside `goToSlide`. It seems that `beforeChange` was not updated to use this new value and it relied on the `index` being already corrected for the wrap around calculations. Now that it wasn't receiving the modified index, it was passing through the unexpected `-1`.

## Fix
Use `newIndex`

## Other changes
While updating the test to validate this condition, was noticed that the `should wrap around from the first to last slide if infinite is true and prev is clicked` test was a copy/paste of the previous test that tested the opposite condition. Have fixed this to correctly test the previous button wrap around.
