### PR TITLE
fix: Styling fixes for RTL documents and element hover

### DIFF
--- a/src/carousel.less
+++ b/src/carousel.less
@@ -13,7 +13,7 @@
   .carousel-viewport {
     overflow: hidden;
     white-space: nowrap;
-    text-align: left;
+    text-align: start;
   }
 
   .carousel-arrow-default {

--- a/src/rtl.less
+++ b/src/rtl.less
@@ -1,8 +1,4 @@
 [dir="rtl"] .carousel {
-  .carousel-viewport {
-    text-align: right;
-  }
-
   .carousel-left-arrow {
     left: unset;
     right: 23px;

--- a/src/stories/index.stories.jsx
+++ b/src/stories/index.stories.jsx
@@ -470,12 +470,37 @@ export const RightAlignedSlides = {
   }
 };
 
+const RTL_TEXT_SLIDES = [
+  { label: 'RTL ←', text: 'Hello' },
+  { label: 'RTL ←', text: 'World' },
+  { label: 'RTL ←', text: 'Test' },
+  { label: 'RTL ←', text: '1' },
+  { label: 'RTL ←', text: '2' },
+  { label: 'RTL ←', text: '3' }
+].map(({ label, text }, index) => (
+  <div
+    key={ index }
+    style={{
+      minHeight: '200px',
+      padding: '24px',
+      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      color: '#fff',
+      fontSize: '24px',
+      width: '250px',
+      borderRadius: '8px'
+    }}
+  >
+    <span style={{ fontSize: '14px', opacity: 0.9 }}>{label}</span>
+    <span>{text}</span>
+  </div>
+));
+
 export const Rtl = {
   args: {
     width: '450px',
     cellPadding: 5,
     dir: 'rtl',
-    children: imgElements
+    children: RTL_TEXT_SLIDES
   },
   render: (args) => (
     <div dir='rtl'>


### PR DESCRIPTION
## Summary

There are a few bugs that need to be fixed.

1: Carousel cuts off any overflow which causes hover tooltips to not display properly.
2. Specifying text-align left or right causes issues if consumers use `webpack-rtl-plugin` as this reverts any instances of left to right, and vice versa.

## Changelog

1: Fixed issue by specifying overflow y: visible so hover elements can display properly.

Before:
<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/3dd02527-4ebf-4a2b-9216-73e51b9d20ae" />

After:
<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/37d85e54-bead-4c2b-9c86-31c34b97ae77" />

2: Fixed issue by changing text-align: left to text-align: start which respects document direction attribute.

Before:
<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/760ab60a-eb99-4765-8acc-d9824b4dfcf2" />


After:
<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/858fd7b3-4f60-4c2c-bacd-fc40730b8eab" />


## Test Plan

Manual testing and verifying storybook cases.